### PR TITLE
Fixing compiler warnings

### DIFF
--- a/truncate_core/src/bag.rs
+++ b/truncate_core/src/bag.rs
@@ -1,8 +1,6 @@
 use oorandom::Rand32;
 use std::fmt;
 
-use crate::rules;
-
 /*
 INFO: Letter distributions in Truncate's dict
 

--- a/truncate_core/src/board.rs
+++ b/truncate_core/src/board.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::array::IntoIter;
 use std::collections::{HashSet, VecDeque};
 use std::fmt;
-use std::iter::{FilterMap, Flatten};
+use std::iter::Flatten;
 use std::slice::Iter;
 
 use super::reporting::{BoardChange, BoardChangeAction, BoardChangeDetail};
@@ -12,7 +12,7 @@ use crate::error::GamePlayError;
 use crate::judge::WordDict;
 use crate::reporting::Change;
 use crate::rules::{ArtifactDefense, GameRules, WinCondition};
-use crate::{player, rules};
+use crate::rules;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Direction {
@@ -1346,12 +1346,12 @@ impl Board {
                         }
                     }
 
-                    for (coord, square) in self.neighbouring_squares(coord) {
+                    for (coord, _) in self.neighbouring_squares(coord) {
                         visible_coords.insert(coord);
                     }
                 }
                 Ok(Square::Occupied {
-                    player, validity, ..
+                    player, ..
                 }) if player == player_index => {
                     let word_coords = self.get_words(coord);
                     let valid = word_coords

--- a/truncate_core/src/game.rs
+++ b/truncate_core/src/game.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ops::Sub;
 
 use time::Duration;
 use xxhash_rust::xxh3;
@@ -368,7 +367,7 @@ impl Game {
                     player.paused_turn_delta = None;
                 }
             }
-            rules::Timing::PerTurn { time_allowance } => unimplemented!(),
+            rules::Timing::PerTurn { time_allowance: _ } => unimplemented!(),
             rules::Timing::None => { /* no-op */ }
         }
     }

--- a/truncate_core/src/generation.rs
+++ b/truncate_core/src/generation.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BinaryHeap, HashSet, VecDeque},
-    ops::{Add, Div, Mul},
+    ops::{Add, Div},
 };
 
 use noise::{NoiseFn, Simplex};

--- a/truncate_core/src/rules.rs
+++ b/truncate_core/src/rules.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     board::Board,
     generation::{
-        ArtifactType, BoardElements, BoardNoiseParams, BoardParams, BoardSeed, Symmetry, WaterLayer,
+        ArtifactType, BoardElements, BoardNoiseParams, BoardParams, Symmetry, WaterLayer,
     },
 };
 


### PR DESCRIPTION
Fixes for:
```
warning: unused import: `std::ops::Sub`
 --> truncate_core/src/game.rs:2:5
  |
2 | use std::ops::Sub;
  |     ^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `Mul`
 --> truncate_core/src/generation.rs:3:21
  |
3 |     ops::{Add, Div, Mul},
  |                     ^^^

warning: unused import: `BoardSeed`
 --> truncate_core/src/rules.rs:8:69
  |
8 | ...ardNoiseParams, BoardParams, BoardSeed, Symmetry, WaterLayer,
  |                                 ^^^^^^^^^

warning: unused variable: `square`
    --> truncate_core/src/board.rs:1349:33
     |
1349 | ...           for (coord, square) in self.neighbouring_squares(coor...
     |                           ^^^^^^ help: if this is intentional, prefix it with an underscore: `_square`
     |
     = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `validity`
    --> truncate_core/src/board.rs:1354:29
     |
1354 |                     player, validity, ..
     |                             ^^^^^^^^ help: try ignoring the field: `validity: _`

warning: unused variable: `time_allowance`
   --> truncate_core/src/game.rs:371:38
    |
371 | ...s::Timing::PerTurn { time_allowance } => unimplemented!(),
    |                         ^^^^^^^^^^^^^^ help: try ignoring the field: `time_allowance: _`


```
among other warnings